### PR TITLE
Add basic integration test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,10 @@ sudo: required
 services:
     - docker
 
+cache:
+    directories:
+        - $HOME/.cache/mnist/
+
 # Disable automatic submodule fetching to prevent
 # it from being done recursively
 git:
@@ -26,6 +30,8 @@ env:
         - DC=dmd-transitional DIST=xenial F=production
         - DC=dmd-transitional DIST=xenial F=devel
 
-install: beaver install
+install:
+    - beaver install
+    - beaver run script/download-mnist
 
 script: beaver run ci/run.sh

--- a/Build.mak
+++ b/Build.mak
@@ -15,3 +15,7 @@ endif
 .PHONY: download-mnist
 download-mnist: $C/script/download-mnist
 	$(call exec,sh $(if $V,,-x) $^,$(MNIST_DATA_DIR),$^)
+
+$O/test-mxnet.stamp: override LDFLAGS += -lz
+$O/test-mxnet.stamp: override ITFLAGS += $(MNIST_DATA_DIR)
+$O/test-mxnet.stamp: download-mnist

--- a/Build.mak
+++ b/Build.mak
@@ -11,3 +11,7 @@ endif
 # use NaiveEngine (non-threaded) MXNet engine since the default (threaded)
 # version dead locks
 %test: export MXNET_ENGINE_TYPE=NaiveEngine
+
+.PHONY: download-mnist
+download-mnist: $C/script/download-mnist
+	$(call exec,sh $(if $V,,-x) $^,$(MNIST_DATA_DIR),$^)

--- a/docker/build
+++ b/docker/build
@@ -16,4 +16,5 @@ apt-get update
 
 # Install dmxnet dependencies
 apt-get install -y \
-    libmxnet
+    libmxnet \
+    zlib1g-dev

--- a/script/download-mnist
+++ b/script/download-mnist
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+set -eu
+
+download_dir=${1-${MNIST_DATA_DIR-"${HOME}/.cache/mnist"}}
+
+base_url="http://yann.lecun.com/exdb/mnist"
+
+mnist_sha256sums=$(cat <<EOT
+8d422c7b0a1c1c79245a5bcf07fe86e33eeafee792b84584aec276f5a2dbc4e6  t10k-images-idx3-ubyte.gz
+f7ae60f92e00ec6debd23a6088c31dbd2371eca3ffa0defaefb259924204aec6  t10k-labels-idx1-ubyte.gz
+440fcabf73cc546fa21475e81ea370265605f56be210a4024d2ca8f203523609  train-images-idx3-ubyte.gz
+3552534a0a558bbed6aed32b30c495cca23d567ec52cac8be1a0730e8010255c  train-labels-idx1-ubyte.gz
+EOT
+)
+
+mkdir -p "${download_dir}"
+cd "${download_dir}"
+echo "${mnist_sha256sums}" | cut -d' ' -f3 | xargs -I% wget -nv -nc "${base_url}/%"
+echo "${mnist_sha256sums}" | sha256sum --quiet --strict -c

--- a/test/mxnet/MNIST.d
+++ b/test/mxnet/MNIST.d
@@ -1,0 +1,438 @@
+/*******************************************************************************
+
+    Provides functionality to load the images and labels of the MNIST dataset
+
+    The MNIST dataset consists of labeled hand written digits. Each example is
+    a hand written digit `0` to `9` that is labeled with `0` to `9`. The hand
+    written digits are provided as 28x28 black and white images where a pixel's
+    intensity is encoded from 0 (white) to 255 (black).
+
+    The MNIST dataset provides a training and a testing dataset. The training
+    dataset consists of 60000 labeled images. The testing dataset consists of
+    10000 labeled images.
+
+    The dataset can be obtained from <http://yann.lecun.com/exdb/mnist/>.
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH.
+
+    License:
+        Boost Software License Version 1.0.  See accompanying LICENSE.txt for
+        details, or <https://www.boost.org/LICENSE_1_0.txt>
+
+*******************************************************************************/
+
+module test.mxnet.MNIST;
+
+import core.stdc.string;
+import core.sys.posix.arpa.inet;
+
+import ocean.core.Enforce;
+import ocean.io.compress.ZlibStream;
+import ocean.io.device.File;
+import ocean.io.Path;
+import ocean.math.Math;
+import ocean.sys.Environment;
+import ocean.transition;
+
+
+///
+unittest
+{
+    // load the MNIST training dataset
+    auto mnist_training = trainingSet(datasetPath([]));
+    auto images = mnist_training.images;
+    auto labels = mnist_training.labels;
+
+    // dimensions of an image
+    auto image_rows = 28;
+    auto image_cols = 28;
+    assert(labels.length == images.length / (image_rows * image_cols));
+
+    // access the first image and its label
+    auto first_training_image = images[0 .. image_rows * image_cols];
+    auto first_training_label = labels[0];
+
+    // image is stored row wise with values between 0 (white) and 255 (black)
+    auto first_row = first_training_image[0 .. image_rows];
+}
+
+
+/*******************************************************************************
+
+    A Dataset consisting of images with their respective labels
+
+*******************************************************************************/
+
+struct Dataset
+{
+    /***************************************************************************
+
+        Images representing hand-written digits
+
+        Each image is of size 28 x 28 with its (pixel) values between 0 (white)
+        and 255 (black). The pixels are stored row wise and all the images'
+        data are flattened into this array. The i-th image corresponds to the
+        slice `[i * 28 * 28 .. (i + 1) * 28 * 28]` of this array.
+
+    ***************************************************************************/
+
+    ubyte[] images;
+
+
+    /***************************************************************************
+
+        Labels representing the numbers from 0 to 9
+
+        Each label indicates the corresponding digit, i.e., the label `0`
+        encodes the digit 0 and so on.
+
+        The i-th label corresponds to the i-th element of this array.
+
+    ***************************************************************************/
+
+    ubyte[] labels;
+}
+
+
+/*******************************************************************************
+
+    Returns the MNIST training dataset consisting of 60000 examples
+
+    Params:
+        dataset_directory = name of the directory to load the training dataset
+                            from
+
+    Returns:
+        the MNIST training dataset of 60000 images and labels
+
+*******************************************************************************/
+
+public Dataset trainingSet (cstring dataset_directory)
+{
+    auto dataset = Dataset(mnistImages(join(dataset_directory, "train-images-idx3-ubyte.gz")),
+                           mnistLabels(join(dataset_directory, "train-labels-idx1-ubyte.gz")));
+    assert(dataset.images.length == 60 * 1000 * 28 * 28);
+    assert(dataset.labels.length == 60 * 1000);
+    return dataset;
+}
+
+
+/*******************************************************************************
+
+    Returns the MNIST testing dataset consisting of 10000 examples
+
+    From <http://yann.lecun.com/exdb/mnist/>:
+
+    > The first 5000 examples of the test set are taken from the original NIST
+    > training set. The last 5000 are taken from the original NIST test set.
+    > The first 5000 are cleaner and easier than the last 5000.
+
+    Params:
+        dataset_directory = name of the directory to load the training dataset
+                            from
+
+    Returns:
+        the MNIST testing dataset of 10000 images and labels
+
+*******************************************************************************/
+
+public Dataset testingSet (cstring dataset_directory)
+{
+    auto dataset = Dataset(mnistImages(join(dataset_directory, "t10k-images-idx3-ubyte.gz")),
+                           mnistLabels(join(dataset_directory, "t10k-labels-idx1-ubyte.gz")));
+    assert(dataset.images.length == 10 * 1000 * 28 * 28);
+    assert(dataset.labels.length == 10 * 1000);
+    return dataset;
+}
+
+
+/*******************************************************************************
+
+    Determines the path of the MNIST dataset
+
+    Params:
+        args = command line arguments whose second argument, if it exists, is
+               the returned path to the dataset
+
+    Returns:
+        args[1], if args.length == 2;
+        else `MNIST_DATA_DIR` environment variable, if set;
+        else, $HOME/.cache/mnist
+
+*******************************************************************************/
+
+public cstring datasetPath (istring[] args)
+{
+    if (args.length == 2) return args[1];
+
+    auto env_mnist_data_dir = Environment.get("MNIST_DATA_DIR");
+    if (env_mnist_data_dir !is null) return env_mnist_data_dir;
+
+    return join(Environment.get("HOME"), ".cache", "mnist");
+}
+
+
+/*******************************************************************************
+
+    Loads MNIST images from a compressed data file, validating and stripping
+    the header data
+
+    The images are returned in an array. Each image is 28x28 `ubyte`s long.
+
+    Params:
+        filename = name of the file providing gzipped image data
+
+    Throws:
+        if filename cannot be opened or the decompressed file's header is
+        ill-formed
+
+    Returns:
+        array of MNIST image data where each image is represented by a 28 * 28
+        sequence of `ubyte` values (the i-th image corresponds to the slice
+        `[i * 28 * 28 .. (i + 1) * 28 * 28]` of this array)
+
+*******************************************************************************/
+
+private ubyte[] mnistImages (cstring filename)
+{
+    auto decompressed_file_data = decompress(filename);
+
+    ImageFileHeader image_header;
+    memcpy(&image_header, decompressed_file_data.ptr, image_header.sizeof);
+    // must encode a 3-dimensional array of ubyte
+    enforce(ntohl(image_header.magic_number) == 0x00000803);
+    // where each image is 28 x 28
+    enforce(image_header.numRows() == 28);
+    enforce(image_header.numCols() == 28);
+
+    auto data = decompressed_file_data[ImageFileHeader.sizeof .. $];
+    assert(image_header.numImages() * image_header.numRows() * image_header.numCols() == data.length);
+
+    return data;
+}
+
+
+/*******************************************************************************
+
+    Header present at the beginning of each decompressed image file
+
+    The opening bytes of the decompressed image file can be copied to this data
+    structure in order to read the file's header data.
+
+*******************************************************************************/
+
+private struct ImageFileHeader
+{
+    /***************************************************************************
+
+        32-bit integer magic number encoded in big endian
+
+        The first two bytes are always 0.
+        The third byte encodes the type of the data:
+
+            - 0x08 unsigned byte
+            - 0x09 signed byte
+            - 0x0B short (2 bytes)
+            - 0x0C int (4 bytes)
+            - 0x0D float (4 bytes)
+            - 0x0E double (8 bytes)
+
+        The fourth bytes encodes the number of dimensions:
+
+            - 0x01 vector
+            - 0x02 matrix
+            - 0x03 3rd order tensor
+            - ...
+
+    ***************************************************************************/
+
+    private int magic_number;
+
+
+    /***************************************************************************
+
+        32-bit integer number of images encoded in big endian
+
+    ***************************************************************************/
+
+    private int num_images;
+
+
+    /***************************************************************************
+
+        32-bit integer number of rows of an image encoded in big endian
+
+    ***************************************************************************/
+
+    private int num_rows;
+
+
+    /***************************************************************************
+
+        32-bit integer number of cols of an image encoded in big endian
+
+    ***************************************************************************/
+
+    private int num_cols;
+
+
+    /***************************************************************************
+
+        Returns:
+            the number of images according to this image file header
+
+    ***************************************************************************/
+
+    public int numImages ()
+    {
+        return ntohl(this.num_images);
+    }
+
+
+    /***************************************************************************
+
+        Returns:
+            the number of rows of an image according to this image file
+            header
+
+    ***************************************************************************/
+
+    public int numRows ()
+    {
+        return ntohl(this.num_rows);
+    }
+
+
+    /***************************************************************************
+
+        Returns:
+            the number of cols of an image according to this image file
+            header
+
+    ***************************************************************************/
+
+    public int numCols ()
+    {
+        return ntohl(this.num_cols);
+    }
+}
+
+
+/*******************************************************************************
+
+    Loads MNIST labels from a compressed data file, validating and stripping
+    the header data
+
+    The labels are returned in an array. Each element represent a label between
+    `0` and `9`, indicating the digit of the corresponding hand written digit
+    in the image data.
+
+    Params:
+        filename = name of the file providing gzipped label data
+
+    Throws:
+        if filename cannot be opened or the decompressed file's header is
+        ill-formed
+
+    Returns:
+        array of MNIST label data where each label is represented by `ubyte`
+        value between 0 and 9 (the i-th label corresponds to the i-th element
+        of this array)
+
+*******************************************************************************/
+
+private ubyte[] mnistLabels (cstring filename)
+{
+    auto decompressed_file_data = decompress(filename);
+
+    LabelFileHeader label_header;
+    memcpy(&label_header, decompressed_file_data.ptr, label_header.sizeof);
+    // must encode a 1-dimensional array of ubyte
+    enforce(ntohl(label_header.magic_number) == 0x00000801);
+
+    auto data = decompressed_file_data[LabelFileHeader.sizeof .. $];
+    enforce(label_header.numLabels() == data.length);
+
+    return data;
+}
+
+
+/*******************************************************************************
+
+    Header present at the beginning of each decompressed label file
+
+    The opening bytes of the decompressed label file can be copied to this data
+    structure in order to read the file's header data.
+
+*******************************************************************************/
+
+private struct LabelFileHeader
+{
+    /***************************************************************************
+
+        32-bit integer magic number encoded in big endian
+
+    ***************************************************************************/
+
+    private int magic_number;
+
+
+    /***************************************************************************
+
+        32-bit integer number of labels encoded in big endian
+
+    ***************************************************************************/
+
+    private int num_labels;
+
+
+    /***************************************************************************
+
+        Returns:
+            the number of labels according to this label file header
+
+    ***************************************************************************/
+
+    public int numLabels ()
+    {
+        return ntohl(this.num_labels);
+    }
+}
+
+
+/*******************************************************************************
+
+    Loads a gzipped file from disk and decompresses its contents into an array
+
+    Params:
+        filename = name of the gzipped file
+
+    Returns:
+        the decompressed contents of file with given filename
+
+*******************************************************************************/
+
+private ubyte[] decompress (cstring filename)
+{
+    void[] buffer;
+    File.get(filename, buffer);
+    ubyte[] data = cast(ubyte[]) buffer;
+
+    auto decompress = new ZlibStreamDecompressor();
+    ubyte[] decompressed_data;
+    decompress.start(ZlibStreamDecompressor.Encoding.Gzip);
+    while (data.length)
+    {
+        auto offset = min(1024, data.length);
+        decompress.decodeChunk(data[0 .. offset],
+                               (ubyte[] decompressed_chunk)
+                               {
+                                   decompressed_data ~= decompressed_chunk;
+                               });
+        data = data[offset .. $];
+    }
+    decompress.end();
+
+    return decompressed_data;
+}

--- a/test/mxnet/main.d
+++ b/test/mxnet/main.d
@@ -1,0 +1,255 @@
+/*******************************************************************************
+
+    Performs multi-class logistic regression on the MNIST dataset using MXNet
+
+    Copyright:
+        Copyright (c) 2017 sociomantic labs GmbH.
+
+    License:
+        Boost Software License Version 1.0.  See accompanying LICENSE.txt for
+        details, or <https://www.boost.org/LICENSE_1_0.txt>
+
+*******************************************************************************/
+
+module test.mxnet.main;
+
+import MNIST = test.mxnet.MNIST;
+
+import mxnet.MXNet;
+
+import ocean.core.Test;
+import ocean.io.Stdout;
+import ocean.time.StopWatch;
+import ocean.transition;
+import ocean.util.Convert;
+
+
+void main (istring[] args)
+{
+    auto mnist_dataset_dir = MNIST.datasetPath(args);
+
+    // mnist dataset dimensions
+    uint num_pixels = 784;
+    uint num_classes = 10;
+    uint training_size = 60000;
+    uint testing_size = 10000;
+
+    Stdout.formatln("MXNet handles in use at start: {}", handleCount());
+    scope (exit)
+    {
+        Stdout.formatln("MXNet handles in use at exit: {}", handleCount());
+    }
+
+    // load and prepare MNIST dataset
+    auto mnist_training = MNIST.trainingSet(mnist_dataset_dir);
+    auto mnist_training_images = to!(float[])(mnist_training.images);
+    test!("==")(mnist_training_images.length, training_size * num_pixels);
+    mnist_training_images[] /= 255;
+    auto mnist_training_labels = to!(float[])(mnist_training.labels);
+    test!("==")(mnist_training_labels.length, training_size);
+
+    auto mnist_testing = MNIST.testingSet(mnist_dataset_dir);
+    auto mnist_testing_images = to!(float[])(mnist_testing.images);
+    test!("==")(mnist_testing_images.length, testing_size * num_pixels);
+    mnist_testing_images[] /= 255;
+    auto mnist_testing_labels = to!(size_t[])(mnist_testing.labels);
+    test!("==")(mnist_testing_labels.length, testing_size);
+
+    // creating the network
+    // inputs
+    scope x_symbol = new Variable("X"); // feature matrix
+    scope (exit) x_symbol.freeHandle();
+    scope y_symbol = new Variable("y"); // label vector
+    scope (exit) y_symbol.freeHandle();
+
+    // network architecture including variables
+    scope w_symbol = new Variable("W");
+    scope (exit) w_symbol.freeHandle();
+    scope fc = new FullyConnected(x_symbol, num_classes, w_symbol);
+    scope (exit) fc.freeHandle();
+    scope softmax = new SoftmaxOutput(fc, y_symbol);
+    scope (exit) softmax.freeHandle();
+
+    // setup context to carry out computations
+    auto context = cpuContext();
+    // size of a training batch
+    auto batch_size = 100;
+    // parameter X
+    scope matrix_x = new NDArray!(float)(context, [batch_size, num_pixels]);
+    scope (exit) matrix_x.freeHandle();
+    // parameter y
+    scope vector_y = new NDArray!(float)(context, [batch_size]);
+    scope (exit) vector_y.freeHandle();
+
+    // variable W initialized to zero
+    scope matrix_w = new NDArray!(float)(context, [num_classes, num_pixels], 0f);
+    scope (exit) matrix_w.freeHandle();
+
+    NDArray!(float)[] variables = [matrix_x,
+                                   matrix_w,
+                                   vector_y];
+
+    // gradient w.r.t. W
+    scope gradient_w = new NDArray!(float)(context, matrix_w.shape());
+    scope (exit) gradient_w.freeHandle();
+
+    NDArray!(float)[] gradients = [NDArray!(float).init,  // no gradient for inputs
+                                   gradient_w,
+                                   NDArray!(float).init]; // no gradient for outputs
+
+    auto gradients_req_type = [Executor!(float).OpReq.null_op,
+                               Executor!(float).OpReq.write,
+                               Executor!(float).OpReq.null_op];
+
+    // verify that the all variables are provided in proper order
+    assert(softmax.arguments == ["X", "W", "y"]);
+    // define the executor binding the model with the parameters (data) and variables
+    scope executor = new Executor!(float)(context, softmax, variables, gradients,
+                                          gradients_req_type, []);
+    scope (exit) executor.freeHandle();
+
+    // training
+    auto num_iterations = 4000;
+    StopWatch watch;
+    watch.start();
+    for (size_t i = 0; i < num_iterations; ++i)
+    {
+        assert(training_size % batch_size == 0);
+        auto num_batches_per_epoch = training_size / batch_size;
+        auto ii = i % num_batches_per_epoch;
+
+        // extract batch from training set
+        auto images_batch = mnist_training_images[ii * batch_size * num_pixels .. (ii + 1) * batch_size * num_pixels];
+        auto labels_batch = mnist_training_labels[ii * batch_size .. (ii + 1) * batch_size];
+
+        assert(images_batch.length == batch_size * num_pixels);
+        assert(labels_batch.length == batch_size);
+
+        // set batch and ...
+        matrix_x.data()[] = images_batch;
+        vector_y.data()[] = labels_batch;
+
+        // make a forward and a backward pass
+        executor.forward();
+        executor.backward();
+        auto step_length = 5e-1f;
+        // and update variable in direction of negative gradient
+        gradient_w *= step_length;
+        matrix_w -= gradient_w;
+    }
+    auto iteration_time_sec = watch.stop();
+
+    auto predicted_testing_labels = predict(softmax, matrix_w, testing_size, mnist_testing_images);
+    auto testing_accuracy = accuracy(predicted_testing_labels, mnist_testing_labels);
+    // prediction on testing
+    test!(">=")(testing_accuracy, 0.915);
+    Stdout.formatln("Percentage of correctly predicted digits on MNIST testing: {:f4}%", testing_accuracy);
+    Stdout.formatln("Calculated in {:f6} seconds", iteration_time_sec);
+    Stdout.formatln("MXNet handles in use at finish: {}", handleCount());
+}
+
+
+/*******************************************************************************
+
+    Predicts the labels for MNIST digit images
+
+    Params:
+        model = the model used for prediction
+        matrix_w = learned parameters of model
+        num_images = number of images
+        images = digit images data
+
+    Returns:
+        the predicted label for each image
+
+*******************************************************************************/
+
+size_t[] predict (Symbol model, NDArray!(float) matrix_w,
+                  uint num_images, Const!(float)[] images)
+{
+    assert(images.length % num_images == 0);
+    uint num_pixels = to!(uint)(images.length) / num_images;
+
+    scope matrix_x = new NDArray!(float)(cpuContext(), [num_images, num_pixels]);
+    scope (exit) matrix_x.freeHandle();
+    matrix_x.data()[] = images;
+    scope vector_y = new NDArray!(float)(cpuContext(), [num_images]);
+    scope (exit) vector_y.freeHandle();
+
+    NDArray!(float)[] variables = [matrix_x,
+                                   matrix_w,
+                                   vector_y];
+
+    NDArray!(float)[] gradients = [NDArray!(float).init,
+                                   NDArray!(float).init,
+                                   NDArray!(float).init];
+
+    auto gradients_req_type = [Executor!(float).OpReq.null_op,
+                               Executor!(float).OpReq.null_op,
+                               Executor!(float).OpReq.null_op];
+
+    scope executor = new Executor!(float)(cpuContext(), model, variables, gradients,
+                                          gradients_req_type, []);
+    scope (exit) executor.freeHandle();
+
+    executor.forward(ForwardPass.outputs);
+    scope output = new NDArray!(float)(null);
+    scope (exit) output.freeHandle();
+    auto outputs = [output];
+    executor.outputs(outputs);
+    auto predictions_vector = to!(float[])(output.data());
+
+    auto predictions = new size_t[num_images];
+    for (uint i = 0; i < num_images; ++i)
+    {
+        uint num_classes = 10;
+        auto prediction = predictions_vector[i * num_classes .. (i + 1) * num_classes];
+
+        // search for label with largest prediction probability
+        // (this is basically a `foldr` operation on the index
+        // values, so could be replaced by that in future if a
+        // `fold` implementation becomes available)
+        size_t predicted_label = 0;
+        for (size_t label = 1; label < num_classes; ++label)
+        {
+            assert(prediction[label] >= 0);
+            if (prediction[label] > prediction[predicted_label])
+            {
+                predicted_label = label;
+            }
+        }
+        assert(predicted_label < num_classes);
+
+        predictions[i] = predicted_label;
+    }
+
+    return predictions;
+}
+
+
+/*******************************************************************************
+
+    Calculates the percentages of correctly predicted labels
+
+    Params:
+        predicted_labels = predicted labels
+        expected_labels = expected labels
+
+    Returns:
+        the percentage of labels in predicted_labels that was predicted
+        correctly w.r.t. expected_labels
+
+*******************************************************************************/
+
+double accuracy (Const!(size_t)[] predicted_labels, Const!(size_t)[] expected_labels)
+{
+    assert(expected_labels.length == predicted_labels.length);
+
+    size_t correct_predicted = 0;
+    for (size_t i = 0; i < predicted_labels.length; ++i)
+    {
+        correct_predicted += predicted_labels[i] == expected_labels[i];
+    }
+
+    return (1.0 * correct_predicted) / predicted_labels.length;
+}


### PR DESCRIPTION
These patches add support for a basic integration test suite that performs multi-class logistic regression on the MNIST dataset using the D MXNet wrapper library.  It does not provide comprehensive coverage (and is not intended to), but should provide a basic sanity check of the library's behaviour.

A script and build target to download the MNIST dataset have been added, and the docker build script has been updated to ensure that the CI docker image will include the dataset already baked in.  This should help to minimize the amount of downloading required (for our sake and MNIST's).