### PR TITLE
Add D2 builds to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,13 @@ env:
     global:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH)"
+        - BEAVER_DOCKER_VARS="DC F"
     matrix:
-        - DIST=xenial F=production
-        - DIST=xenial F=devel
+        - DC=dmd1 DIST=xenial F=production
+        - DC=dmd1 DIST=xenial F=devel
+        - DC=dmd-transitional DIST=xenial F=production
+        - DC=dmd-transitional DIST=xenial F=devel
 
 install: beaver install
 
-script: beaver make test all
+script: beaver run ci/run.sh

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -eux
+
+DVER=1
+if test "$DC" != dmd1; then
+	DVER=2
+fi
+
+export DC DVER
+
+if test "$DC" != dmd1; then
+	make -r d2conv
+fi
+
+make -r all
+make -r test


### PR DESCRIPTION
The original `matrix:` setup only included D1 builds.  This patch should ensure that both D1 and D2 builds are carried out by Travis.