### PR TITLE
Update makd from v1.9.1 to v1.10.0

### DIFF
--- a/Config.mak
+++ b/Config.mak
@@ -1,0 +1,1 @@
+INTEGRATIONTEST := integrationtest

--- a/integrationtest/mxnet/MNIST.d
+++ b/integrationtest/mxnet/MNIST.d
@@ -22,7 +22,7 @@
 
 *******************************************************************************/
 
-module test.mxnet.MNIST;
+module integrationtest.mxnet.MNIST;
 
 import core.stdc.string;
 import core.sys.posix.arpa.inet;

--- a/integrationtest/mxnet/main.d
+++ b/integrationtest/mxnet/main.d
@@ -11,9 +11,9 @@
 
 *******************************************************************************/
 
-module test.mxnet.main;
+module integrationtest.mxnet.main;
 
-import MNIST = test.mxnet.MNIST;
+import MNIST = integrationtest.mxnet.MNIST;
 
 import mxnet.MXNet;
 


### PR DESCRIPTION
This update allows us to switch the location of the integration test directory, which should in turn enable the project to build with more recent versions of the D2 compiler.

* submodules/makd v1.9.1(8711da2)...v1.10.0(ab31113) (11 commits)
  > Add targets to build examples
  > test: Add exception for importing x.y.package
  > Allow overriding d1to2fix binary and directories
  > Do not colorize output for dmd when DVER=2
  > Add a exec_nc function for non-colorized output
  (...)