### PR TITLE
Add debugging help when freeing handles in the destructor

### DIFF
--- a/src/mxnet/Handle.d
+++ b/src/mxnet/Handle.d
@@ -432,14 +432,16 @@ public class MXNetHandle (HandleType, alias FreeHandleFunction)
         {
             if (this.exists())
             {
-                // we require manual resource management by calling
-                // `freeHandle` to free MXNet resources explicitly and never
-                // rely on the destructor
+                // Relying on the GC calling this destructor to free the handle
+                // is problematic since it may not be in-time. For this reason,
+                // we recommend users of `MXNetHandle` to free MXNet resources
+                // by calling `freeHandle` manually, and never relying on the
+                // destructor.
                 //
-                // relying on the GC calling this destructor to free the handle
-                // is problematic since it may not be in-time
-                // performing a manual `delete` or `destroy` is technically
-                // fine but forbidden by policy
+                // If this policy is followed, then the handle should already
+                // have been freed by the time the destructor is initiated.
+                // This debug check should help in tracking down any handles
+                // for which this has not been done.
                 sformat((cstring str) { write(STDERR_FILENO, str.ptr, str.length); },
                         "Non-null handle {:x} in MXNetHandle destructor!\n",
                         this.c_api_handle);

--- a/src/mxnet/Handle.d
+++ b/src/mxnet/Handle.d
@@ -428,6 +428,23 @@ public class MXNetHandle (HandleType, alias FreeHandleFunction)
 
     public ~this ()
     {
+        debug (MXNetHandleManualFree)
+        {
+            if (this.exists())
+            {
+                // we require manual resource management by calling
+                // `freeHandle` to free MXNet resources explicitly and never
+                // rely on the destructor
+                //
+                // relying on the GC calling this destructor to free the handle
+                // is problematic since it may not be in-time
+                // performing a manual `delete` or `destroy` is technically
+                // fine but forbidden by policy
+                sformat((cstring str) { write(STDERR_FILENO, str.ptr, str.length); },
+                        "Non-null handle {:x} in MXNetHandle destructor!\n",
+                        this.c_api_handle);
+            }
+        }
         this.freeHandle();
     }
 }


### PR DESCRIPTION
Freeing non-null handles in the destructor is considered to be a
programming error because they should be freed by an explicit call to
`freeHandle`. This change adds debugging output when a non-null handle
is freed inside the destructor. Because relying on the GC for freeing a
handle in time is not reliable. It is reliable for `delete` or `destroy`
but we prefer an explicit call to `freeHandle` prior to a manual
`delete` or `destroy`. The policy is to always free the handle manually
using `freeHandle`.

This debugging diagnostics is enabled for `MXNetHandleManualFree` debug
builds.