### PR TITLE
Report missing manual free when running integration tests

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -18,4 +18,5 @@ download-mnist: $C/script/download-mnist
 
 $O/test-mxnet.stamp: override LDFLAGS += -lz
 $O/test-mxnet.stamp: override ITFLAGS += $(MNIST_DATA_DIR)
+$O/test-mxnet.stamp: override DFLAGS += -debug=MXNetHandleManualFree
 $O/test-mxnet.stamp: download-mnist


### PR DESCRIPTION
For integration tests any handle that is not freed by having called
`freeHandle` will be reported. These checks are enabled by adding the
recently introduced debugging checks `MXNetHandleManualFree` when
building the integration tests. This helps to track down missing calls
to `freeHandle` when running these tests during development.