### PR TITLE
Ensure build and runtime flags for test suite are set correctly

### DIFF
--- a/Build.mak
+++ b/Build.mak
@@ -16,7 +16,10 @@ endif
 download-mnist: $C/script/download-mnist
 	$(call exec,sh $(if $V,,-x) $^,$(MNIST_DATA_DIR),$^)
 
-$O/test-mxnet.stamp: override LDFLAGS += -lz
+# extra build dependencies for integration tests
+$O/test-mxnet: override LDFLAGS += -lz
+$O/test-mxnet: override DFLAGS += -debug=MXNetHandleManualFree
+
+# extra runtime dependencies for integration tests
 $O/test-mxnet.stamp: override ITFLAGS += $(MNIST_DATA_DIR)
-$O/test-mxnet.stamp: override DFLAGS += -debug=MXNetHandleManualFree
 $O/test-mxnet.stamp: download-mnist


### PR DESCRIPTION
Build dependencies should be added to the `$O/test-feature` target, and only runtime flags should be added via `$O/test-feature.stamp`:
https://github.com/sociomantic-tsunami/makd/tree/v1.10.x#adding-specific-flags

This should fix issues observed with makd v2.0.1, where custom `DFLAGS` were not being added correctly to integration test builds.