### PR TITLE
Fix passing a float for appropriate MXNet operations

### DIFF
--- a/src/mxnet/NDArray.d
+++ b/src/mxnet/NDArray.d
@@ -600,7 +600,7 @@ public class NDArray (T)
 
     ***************************************************************************/
 
-    public void opAssign (T scalar)
+    public void opAssign (float scalar)
     in
     {
         assert(this.mxnet_ndarray.exists());
@@ -742,7 +742,7 @@ public class NDArray (T)
 
     ***************************************************************************/
 
-    public NDArray opMulAssign (T rhs)
+    public NDArray opMulAssign (float rhs)
     in
     {
         assert(this.mxnet_ndarray.exists());
@@ -1377,7 +1377,7 @@ unittest
 private NDArray!(T) applyScalarOp (T) (istring op_name,
                                        NDArray!(T) result,
                                        NDArray!(T) lhs,
-                                       T rhs)
+                                       float rhs)
 in
 {
     assert(endsWith(op_name, "_scalar"));


### PR DESCRIPTION
When assigning each element of an n-dimensional array from a scalar, the
scalar should be of type float according to the MXNet documentation for
the operator `_set_value`. Also the operations with a scalar right-hand
side like `_plus_scalar`, `_minus_scalar`, `_mul_scalar`, `_div_scalar`,
etc. require the scalar to be of type float. This change replaces the
general type `T` with `float` for these cases.