### PR TITLE
Upgrade to v3 of dlang dockerfile

### DIFF
--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,3 +1,3 @@
-FROM sociomantictsunami/dlang:v2
+FROM sociomantictsunami/dlang:v3
 COPY docker/ /docker-tmp
 RUN /docker-tmp/build && rm -fr /docker-tmp


### PR DESCRIPTION
This upgraded dockerfile should come with explicitly pinned versions of various packages (e.g. D compilers).  This should make for a more stable testing environment.