### PR TITLE
Prepare release notes for the upcoming v0.2.0

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,14 +18,55 @@ Further design constraints include:
   been tested with a single-threaded ``libmxnet``
 
 
-D2 compatibility
-================
+Build/Use
+=========
+
+Dependencies
+------------
+
+Packages
+********
+
+``libmxnet`` (``-lmxnet``) v0.10.x is required to build, and can be installed
+from the package provided in our `deb repository
+<https://bintray.com/sociomantic-tsunami/mxnet/libmxnet>`_.
+
+``zlib`` (``-lz``) is required in order to run integration tests, and can be
+installed (on Debian/Ubuntu systems) via the ``zlib1g-dev`` package.
+
+Submodules
+**********
+
+========== =======
+Dependency Version
+========== =======
+makd       v2.0.x
+ocean      v3.5.x
+========== =======
+
+``beaver`` 0.2.x is used by the Travis CI setup, but this submodule can be
+ignored for general development or use of the library.
+
+If you plan to use the provided ``Makefile`` (you will need it to convert code
+to D2 or to run integration tests), you will also need to check out submodules
+with ``git submodule update --init``.  This will fetch source code for `Makd
+<https://github.com/sociomantic-tsunami/makd>`_ (used by the ``Makefile``)
+into ``submodules/makd``.  It will also check out the source code for ``ocean``
+and ``beaver``.
+
+Conversion to D2
+----------------
 
 By default all ``dmxnet`` development is done in D1, but using a subset that is
-almost D2 compatible, and can be auto-converted to D2 using ``d1to2fix`` (e.g.
-via makd's ``make d2conv`` target).  The ``dmd-transitional`` compiler provided
-in <https://github.com/sociomantic-tsunami/dmd-transitional> must be used to
-build the converted D2 code.
+almost D2 compatible, and can be auto-converted to D2 using `d1to2fix
+<https://github.com/sociomantic-tsunami/d1to2fix>_`.  If you are using ``Makd``
+there is a handy built-in target you can use::
+
+  make d2conv
+
+You will need to use the `dmd-transitional
+<https://github.com/sociomantic-tsunami/dmd-transitional>`_ compiler to build
+the converted D2 code.
 
 
 Versioning
@@ -47,3 +88,30 @@ Support Guarantees
 Given the early ``0.x`` state of development, only the latest minor release will
 be supported.  This policy will be updated once a ``1.0.0`` release has been
 made.
+
+
+Releases
+========
+
+`Latest release notes
+<https://github.com/sociomantic-tsunami/dmxnet/releases/latest>`_ | `All
+releases <https://github.com/sociomantic-tsunami/dmxnet/releases>`_
+
+Releases are handled using GitHub releases.  The notes associated with a major
+or minor github release are designed to help developers to migrate from one
+version to another. The changes listed are the steps you need to take to move
+from the previous version to the one listed.
+
+The release notes are structured in 3 sections, a **Migration Instructions**,
+which are the mandatory steps that users have to do to update to a new version,
+**Deprecated** which contains deprecated functions that are recommended not to
+use but will not break any old code, and the **New Features** which are optional
+new features available in the new version that users might find interesting.
+Using them is optional, but encouraged.
+
+
+Contributing
+============
+
+See the guide for `contributing to Neptune-versioned libraries
+<https://github.com/sociomantic-tsunami/neptune/blob/master/doc/library-contributor.rst>`_.

--- a/relnotes/debug-handle-manual-free.feature.md
+++ b/relnotes/debug-handle-manual-free.feature.md
@@ -1,0 +1,7 @@
+* ``-debug=MXNetHandleManualFree``
+
+  When this new debug option is enabled, the library will report to
+  ``stderr`` whenever a MXNet handle is freed by the ``Handle`` class
+  destructor instead of by an explicit call to the ``freeHandle``
+  method.  This can be used to track down leaks of MXNet-allocated
+  resources in an application using dmxnet.

--- a/relnotes/debug-report.feature.md
+++ b/relnotes/debug-report.feature.md
@@ -1,0 +1,6 @@
+* ``mxnet.Handle.debugReport``
+
+  This `private` function has been added to provide a standard means
+  of writing debug error messages to ``stderr``.  All existing debug
+  messages in the ``mxnet.Handle`` module are now provided by calls
+  to this function.

--- a/relnotes/dot-symbol.feature.md
+++ b/relnotes/dot-symbol.feature.md
@@ -1,0 +1,5 @@
+* ``mxnet.Symbol.Dot``
+
+  The new ``Dot`` class wraps the ``dot`` atomic symbol provided
+  by the C++ MXNet library.  This represents a   generalized dot
+  product of its inputs.

--- a/relnotes/integrationtest.migration.md
+++ b/relnotes/integrationtest.migration.md
@@ -1,0 +1,1 @@
+* Integration tests have moved from ``test/`` to ``integrationtest/``.

--- a/relnotes/ndarray-doc.feature.md
+++ b/relnotes/ndarray-doc.feature.md
@@ -1,0 +1,4 @@
+* ``mxnet.NDArray.NDArray``
+
+  Some small documentation improvements have been added to the
+  `opSubAssign` and `opMulAssign` methods.

--- a/relnotes/softmaxoutput-symbol-doc.feature.md
+++ b/relnotes/softmaxoutput-symbol-doc.feature.md
@@ -1,0 +1,4 @@
+* ``mxnet.Symbol.SoftmaxOutput``
+
+  Improved and extended documentation has been provided for the
+  ``SoftmaxOutput`` class.

--- a/relnotes/travis.migration.md
+++ b/relnotes/travis.migration.md
@@ -1,0 +1,2 @@
+* Travis config now uses the ``beaver dlang`` functionality provided
+  in beaver 0.2.x.


### PR DESCRIPTION
These patches add a `Build/Use` section to the `README` file that covers dependencies (including submodule versions), and adds Neptune-style release notes for all changes made since the v0.1.0 release.