### PR TITLE
Fix usage of SoftmaxOutput multi_output constructor parameter flag

### DIFF
--- a/src/mxnet/Symbol.d
+++ b/src/mxnet/Symbol.d
@@ -810,7 +810,7 @@ public class SoftmaxOutput : Symbol
         cstring ignore_label_str = toNoLossString(ignore_label, buf_ignore_label);
         buf_ignore_label[ignore_label_str.length] = '\0';
 
-        istring multi_output_str = use_ignore ? "true" : "false";
+        istring multi_output_str = multi_output ? "true" : "false";
 
         istring preserve_shape_str = preserve_shape ? "true" : "false";
 


### PR DESCRIPTION
This looks like a copy-paste error from back when the library was first created.