### PR TITLE
Fix some oversights in the README file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Conversion to D2
 
 By default all ``dmxnet`` development is done in D1, but using a subset that is
 almost D2 compatible, and can be auto-converted to D2 using `d1to2fix
-<https://github.com/sociomantic-tsunami/d1to2fix>_`.  If you are using ``Makd``
+<https://github.com/sociomantic-tsunami/d1to2fix>`_.  If you are using ``Makd``
 there is a handy built-in target you can use::
 
   make d2conv

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Submodules
 ========== =======
 Dependency Version
 ========== =======
-makd       v2.0.x
+makd       v2.1.x
 ocean      v3.5.x
 ========== =======
 


### PR DESCRIPTION
These patches fix a couple of small oversights: updating the reported `makd` dependency, and correcting a typo in the `d1to2fix` project link.