### PR TITLE
Update base docker image to dlang:v4

### DIFF
--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,3 +1,3 @@
-FROM sociomantictsunami/dlang:v3
+FROM sociomantictsunami/dlang:v4
 COPY docker/ /docker-tmp
 RUN /docker-tmp/build && rm -fr /docker-tmp


### PR DESCRIPTION
This new dlang base image provides tangort 1.8.x and DMD 2.078.x.  This should allow us to make progress with dmxnet support for multithreading MXNet engines.

Part of sociomantic-tsunami/dmxnet#53.