### PR TITLE
Provide support and CI tests for all MXNet engine types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,11 +23,23 @@ env:
     global:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH)"
+        - BEAVER_DOCKER_VARS="MXNET_ENGINE_TYPE"
     matrix:
-        - DMD=dmd1 DIST=xenial F=production
-        - DMD=dmd1 DIST=xenial F=devel
-        - DMD=dmd-transitional DIST=xenial F=production
-        - DMD=dmd-transitional DIST=xenial F=devel
+        - DMD=dmd1 DIST=xenial F=devel MXNET_ENGINE_TYPE=NaiveEngine
+        - DMD=dmd1 DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEngine
+        - DMD=dmd1 DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
+
+        - DMD=dmd1 DIST=xenial F=production MXNET_ENGINE_TYPE=NaiveEngine
+        - DMD=dmd1 DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEngine
+        - DMD=dmd1 DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
+
+        - DMD=dmd-transitional DIST=xenial F=production MXNET_ENGINE_TYPE=NaiveEngine
+        - DMD=dmd-transitional DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEngine
+        - DMD=dmd-transitional DIST=xenial F=production ThreadedEnginePerDevice
+
+        - DMD=dmd-transitional DIST=xenial F=devel MXNET_ENGINE_TYPE=NaiveEngine
+        - DMD=dmd-transitional DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEngine
+        - DMD=dmd-transitional DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
 
 install:
     - beaver dlang install

--- a/Build.mak
+++ b/Build.mak
@@ -8,10 +8,6 @@ ifeq ($(DVER),1)
 	override DFLAGS += -v2 -v2=-static-arr-params -v2=-volatile
 endif
 
-# use NaiveEngine (non-threaded) MXNet engine since the default (threaded)
-# version dead locks
-%test: export MXNET_ENGINE_TYPE=NaiveEngine
-
 .PHONY: download-mnist
 download-mnist: $C/script/download-mnist
 	$(call exec,sh $(if $V,,-x) $^,$(MNIST_DATA_DIR),$^)

--- a/integrationtest/mxnet/main.d
+++ b/integrationtest/mxnet/main.d
@@ -127,8 +127,8 @@ void main (istring[] args)
         assert(labels_batch.length == batch_size);
 
         // set batch and ...
-        matrix_x.data()[] = images_batch;
-        vector_y.data()[] = labels_batch;
+        matrix_x.copyFrom(images_batch);
+        vector_y.copyFrom(labels_batch);
 
         // make a forward and a backward pass
         executor.forward();
@@ -173,7 +173,7 @@ size_t[] predict (Symbol model, NDArray!(float) matrix_w,
 
     scope matrix_x = new NDArray!(float)(cpuContext(), [num_images, num_pixels]);
     scope (exit) matrix_x.freeHandle();
-    matrix_x.data()[] = images;
+    matrix_x.copyFrom(images);
     scope vector_y = new NDArray!(float)(cpuContext(), [num_images]);
     scope (exit) vector_y.freeHandle();
 

--- a/src/mxnet/Executor.d
+++ b/src/mxnet/Executor.d
@@ -247,14 +247,14 @@ public class Executor (T)
         // initialize two dimensional input vector
         scope input = new NDArray!(float)(context, [1, 2]);
         scope (exit) input.freeHandle();
-        input.data[] = [1, 2];
+        input.copyFrom([1, 2]);
         // and label to 1
         scope label = new NDArray!(float)(context, [1], 1f);
         scope (exit) label.freeHandle();
         // and weights
         scope weights = new NDArray!(float)(context, [1, 2]);
         scope (exit) weights.freeHandle();
-        weights.data[] = [0, 0];
+        weights.copyFrom([0, 0]);
         auto inputs = [input, weights, label];
 
         // initialize gradient w.r.t. weights to zero
@@ -279,14 +279,14 @@ public class Executor (T)
                                     input.data[1] * weights.data[1]]);
 
         // test with different inputs
-        input.data[] = [3, 4];
-        label.data[] = [3];
+        input.copyFrom([3, 4]);
+        label.copyFrom([3]);
         executor.forward(ForwardPass.outputs);
         test!("==")(output.data(), [input.data[0] * weights.data[0] +
                                     input.data[1] * weights.data[1]]);
 
         // test with different weights
-        weights.data[] = [3, 4];
+        weights.copyFrom([3, 4]);
         executor.forward(ForwardPass.outputs);
         test!("==")(output.data(), [input.data[0] * weights.data[0] +
                                     input.data[1] * weights.data[1]]);
@@ -339,14 +339,14 @@ public class Executor (T)
         // initialize two dimensional input vector
         scope input = new NDArray!(float)(context, [1, 2]);
         scope (exit) input.freeHandle();
-        input.data[] = [1, 2];
+        input.copyFrom([1, 2]);
         // and label to 1
         scope label = new NDArray!(float)(context, [1], 1f);
         scope (exit) label.freeHandle();
         // and weights
         scope weights = new NDArray!(float)(context, [1, 2]);
         scope (exit) weights.freeHandle();
-        weights.data[] = [0, 0];
+        weights.copyFrom([0, 0]);
         auto inputs = [input, weights, label];
 
         // initialize gradient w.r.t. weights to zero
@@ -372,8 +372,8 @@ public class Executor (T)
                                               (output.data[0] - label.data[0]) * input.data[1]]);
 
         // test with different inputs
-        input.data[] = [3, 4];
-        label.data[] = [3];
+        input.copyFrom([3, 4]);
+        label.copyFrom([3]);
         executor.forward();
         executor.backward();
         // gradient w.r.t. to w
@@ -381,7 +381,7 @@ public class Executor (T)
                                               (output.data[0] - label.data[0]) * input.data[1]]);
 
         // test with different weights
-        weights.data[] = [3, 4];
+        weights.copyFrom([3, 4]);
         executor.forward();
         executor.backward();
         // gradient w.r.t. to w
@@ -465,7 +465,7 @@ public class Executor (T)
         auto context = cpuContext();
         scope input = new NDArray!(float)(context, [2]);
         scope (exit) input.freeHandle();
-        input.data[] = [1, 2];
+        input.copyFrom([1, 2]);
         auto gradients = [NDArray!(float).init];
         auto gradients_ops = [OpReq.null_op];
         scope executor = new Executor(context, model, [input], gradients, gradients_ops, []);

--- a/src/mxnet/NDArray.d
+++ b/src/mxnet/NDArray.d
@@ -708,8 +708,7 @@ public class NDArray (T)
             scope (exit) a.freeHandle();
             scope b = new NDArray(cpuContext(), [2, 1]);
             scope (exit) b.freeHandle();
-            T[] b_data = [1, 2];
-            b.data[] = b_data;
+            b.copyFrom([1, 2]);
             a -= b;
             T[] a_data = [1, 1, 1,
                           0, 0, 0];
@@ -721,8 +720,7 @@ public class NDArray (T)
             scope (exit) a.freeHandle();
             scope b = new NDArray(cpuContext(), [1, 3]);
             scope (exit) b.freeHandle();
-            T[] b_data = [1, 2, 3];
-            b.data[] = b_data;
+            b.copyFrom([1, 2, 3]);
             a -= b;
             T[] a_data = [2, 1, 0,
                           2, 1, 0];


### PR DESCRIPTION
This PR addresses synchronization issues of `NDArray.data` by two changes. The first commit replaces all write to slices obtained by `NDArray.data` by calls using the synchronized `NDArray.copyFrom`. The second commit make `data` return a read-only slice that is synchronized when the method executes. 
This addresses all synchronization issues when using `NDArray.data` in a multi-threaded setup. Hence, the restriction to the `NaiveEngine` is removed from `Build.mak` in the third commit (since this should be the only synchronization issue within `dmxnet` when using a multi-theaded MXNet engine). The fourth commit provides a target to test for all engines. The fifth and last commit instructs Travis to test with all MXNet engines to catch problem with engines during continuous integration.