### PR TITLE
Pass DMD environment variable to be available to beaver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ env:
     global:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH)"
-        - BEAVER_DOCKER_VARS="F"
+        - BEAVER_DOCKER_VARS="F DMD"
     matrix:
         - DMD=dmd1 DIST=xenial F=production
         - DMD=dmd1 DIST=xenial F=devel


### PR DESCRIPTION
Even though the `DMD` environment variable was set inside Travis it
seems it was never passed to beaver. Meaning we never performed D2
builds. This change fixes it by passing the `DMD` environment variable
to beaver.