### PR TITLE
Use `dmd-transitional` by default for D2

### DIFF
--- a/Config.mak
+++ b/Config.mak
@@ -1,1 +1,5 @@
 INTEGRATIONTEST := integrationtest
+
+ifeq ($(DVER),2)
+	DC ?= dmd-transitional
+endif


### PR DESCRIPTION
The README says that for D2 builds the `dmd-transitional` D compiler
should be used. This change defines the compiler to default to
`dmd-transitional` for D2. This way it won't use `dmd` (the standard D2
compiler) by accident. The standard D2 compiler is not supported yet.