### PR TITLE
Update release-notes section titles in line with neptune-release needs

### DIFF
--- a/relnotes/executor-outputs.migration.md
+++ b/relnotes/executor-outputs.migration.md
@@ -1,4 +1,4 @@
-## `NDarray` must have `null` handles when calling `Executor.outputs`
+### `NDarray` must have `null` handles when calling `Executor.outputs`
 
 `mxnet.Executor`
 


### PR DESCRIPTION
The `neptune-release` utility has updated its handling of release notes, such that section titles should have 3 leading hashes (`###`) instead of 2 (`##`).  This patch updates existing notes in line with the new spec:
https://github.com/sociomantic-tsunami/neptune/blob/master/doc/library-contributor.rst#release-notes
https://github.com/sociomantic-tsunami/neptune/commit/79c2451982dd653e9a81e95d9dd0f79fe3135762