### PR TITLE
Enable automatic update PRs for minor versions for makd and beaver

### DIFF
--- a/.neptune.yml
+++ b/.neptune.yml
@@ -1,2 +1,7 @@
 library: true
 d2ready: true
+automatic-update-prs:
+    default: patch
+    override:
+        makd: minor
+        beaver: minor


### PR DESCRIPTION
This change enables providing automatic update PRs to minor versions for
all submodules except ocean for which only patch versions should be
provided.

These changes should result in an automatic PR for updating makd to
v2.2.0 and beaver to v0.6.0.