### PR TITLE
Export MXNET_ENGINE_TYPE from Config.mak if not already set

### DIFF
--- a/Config.mak
+++ b/Config.mak
@@ -1,5 +1,8 @@
 INTEGRATIONTEST := integrationtest
 
+MXNET_ENGINE_TYPE ?= NaiveEngine
+export MXNET_ENGINE_TYPE
+
 ifeq ($(DVER),2)
 	DC ?= dmd-transitional
 endif


### PR DESCRIPTION
This should provide a sensible default engine for local testing, which which may readily be overridden by the user, e.g.:

    MXNET_ENGINE_TYPE=ThreadedEngine make test all

It should not interfere with cases where `MXNET_ENGINE_TYPE` is already set in the build environment.

As a friendly by-product, since this tweak ensures `MXNET_ENGINE_TYPE` is always set, libmxnet should now always log the choice when running tests.