### PR TITLE
Fix MXNET_ENGINE_TYPE settings for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ env:
 
         - DMD=dmd-transitional DIST=xenial F=production MXNET_ENGINE_TYPE=NaiveEngine
         - DMD=dmd-transitional DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEngine
-        - DMD=dmd-transitional DIST=xenial F=production ThreadedEnginePerDevice
+        - DMD=dmd-transitional DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
 
         - DMD=dmd-transitional DIST=xenial F=devel MXNET_ENGINE_TYPE=NaiveEngine
         - DMD=dmd-transitional DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEngine


### PR DESCRIPTION
In one of the test matrix entries the `MXNET_ENGINE_TYPE=` was omitted.  This patch fixes the oversight, ensuring that `ThreadedEnginePerDevice` is tested properly for D2 production builds.