### PR TITLE
Update build scripts to always run tests for all MXNet engine types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ env:
     global:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH)"
-        - BEAVER_DOCKER_VARS="MXNET_ENGINE_TYPE"
 
 # Basic config is inherited from the global scope
 jobs:
@@ -39,32 +38,16 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix
-          env: DMD=dmd1 DIST=xenial F=devel MXNET_ENGINE_TYPE=NaiveEngine
-        - <<: *test-matrix
-          env: DMD=dmd1 DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEngine
-        - <<: *test-matrix
-          env: DMD=dmd1 DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
+          env: DMD=dmd1 DIST=xenial F=devel
 
         - <<: *test-matrix
-          env: DMD=dmd1 DIST=xenial F=production MXNET_ENGINE_TYPE=NaiveEngine
-        - <<: *test-matrix
-          env: DMD=dmd1 DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEngine
-        - <<: *test-matrix
-          env: DMD=dmd1 DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
+          env: DMD=dmd1 DIST=xenial F=production
 
         - <<: *test-matrix
-          env: DMD=dmd-transitional DIST=xenial F=production MXNET_ENGINE_TYPE=NaiveEngine
-        - <<: *test-matrix
-          env: DMD=dmd-transitional DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEngine
-        - <<: *test-matrix
-          env: DMD=dmd-transitional DIST=xenial F=production MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
+          env: DMD=dmd-transitional DIST=xenial F=devel
 
         - <<: *test-matrix
-          env: DMD=dmd-transitional DIST=xenial F=devel MXNET_ENGINE_TYPE=NaiveEngine
-        - <<: *test-matrix
-          env: DMD=dmd-transitional DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEngine
-        - <<: *test-matrix
-          env: DMD=dmd-transitional DIST=xenial F=devel MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
+          env: DMD=dmd-transitional DIST=xenial F=production
 
         # Additional stages
 

--- a/Build.mak
+++ b/Build.mak
@@ -21,7 +21,7 @@ $(1)-$(2).stamp: $1
 endef
 
 # helper function to generate targets for per-engine test runs
-test_with_engines = $(foreach engine,$2,\
+test_with_engines = $(foreach engine,$(TEST_MXNET_ENGINES),\
 	$(eval $(call run_test_with_engine,$1,$(engine))))
 
 # extra build dependencies for integration tests
@@ -29,7 +29,7 @@ $O/test-mxnet: override LDFLAGS += -lz
 $O/test-mxnet: override DFLAGS += -debug=MXNetHandleManualFree
 
 # run integration tests with all specified engines
-$(eval $(call test_with_engines,$O/test-mxnet,$(TEST_MXNET_ENGINES)))
+$(eval $(call test_with_engines,$O/test-mxnet))
 
 # extra runtime dependencies for integration tests
 $O/test-mxnet.stamp: override ITFLAGS += $(MNIST_DATA_DIR)
@@ -39,7 +39,7 @@ $O/test-mxnet.stamp: download-mnist
 $O/%unittests: override LDFLAGS += -lz
 
 # run unittests with all specified engines
-$(eval $(call test_with_engines,$O/allunittests,$(TEST_MXNET_ENGINES)))
+$(eval $(call test_with_engines,$O/allunittests))
 
 $O/allunittests.stamp:
 	$Vtouch $@ # override default implementation

--- a/Build.mak
+++ b/Build.mak
@@ -12,12 +12,25 @@ endif
 download-mnist: $C/script/download-mnist
 	$(call exec,sh $(if $V,,-x) $^,$(MNIST_DATA_DIR),$^)
 
+# helper function to run tests
+run_test = $(call exec,MXNET_ENGINE_TYPE=$2 $1,$1,$2)
+
 # extra build dependencies for integration tests
 $O/test-mxnet: override LDFLAGS += -lz
 $O/test-mxnet: override DFLAGS += -debug=MXNetHandleManualFree
 
 # extra runtime dependencies for integration tests
 $O/test-mxnet.stamp: override ITFLAGS += $(MNIST_DATA_DIR)
-$O/test-mxnet.stamp: download-mnist
+$O/test-mxnet.stamp: $O/test-mxnet download-mnist
+	$(call run_test,$<,NaiveEngine)
+	$(call run_test,$<,ThreadedEngine)
+	$(call run_test,$<,ThreadedEnginePerDevice)
+	$Vtouch $@
 
 $O/%unittests: override LDFLAGS += -lz
+
+$O/allunittests.stamp: $O/allunittests
+	$(call run_test,$<,NaiveEngine)
+	$(call run_test,$<,ThreadedEngine)
+	$(call run_test,$<,ThreadedEnginePerDevice)
+	$Vtouch $@

--- a/Build.mak
+++ b/Build.mak
@@ -13,33 +13,49 @@ download-mnist: $C/script/download-mnist
 	$(call exec,sh $(if $V,,-x) $^,$(MNIST_DATA_DIR),$^)
 
 # helper template to define targets for per-engine test runs
-define run_test_with_engine
+#
+# Params:
+#     $1 = path to executable that runs tests
+#     $2 = name of MXNet engine to use
+define test_with_engine
 $(1).stamp: $(1)-$(2).stamp
 
 $(1)-$(2).stamp: $1
 	$(call exec,MXNET_ENGINE_TYPE=$2 $1,$1,$2)
+	$Vtouch $$@
 endef
 
 # helper function to generate targets for per-engine test runs
-test_with_engines = $(foreach engine,$(TEST_MXNET_ENGINES),\
-	$(eval $(call run_test_with_engine,$1,$(engine))))
+#
+# Params:
+#     $1 = path to executable that runs tests
+define run_test_with_engines
+$(foreach engine,$(TEST_MXNET_ENGINES),\
+	$(eval $(call test_with_engine,$1,$(engine))))
+
+$(1).stamp:
+	$Vtouch $$@  # override default implementation
+endef
+
+define run_test_with_dependency
+$(foreach engine,$(TEST_MXNET_ENGINES),\
+	$(eval $(1)-$(engine).stamp: $2))
+endef
 
 # extra build dependencies for integration tests
 $O/test-mxnet: override LDFLAGS += -lz
 $O/test-mxnet: override DFLAGS += -debug=MXNetHandleManualFree
 
-# run integration tests with all specified engines
-$(eval $(call test_with_engines,$O/test-mxnet))
-
 # extra runtime dependencies for integration tests
-$O/test-mxnet.stamp: override ITFLAGS += $(MNIST_DATA_DIR)
-$O/test-mxnet.stamp: download-mnist
-	$Vtouch $@ # override default implementation
+$(eval $(call run_test_with_dependency,$O/test-mxnet,\
+	override ITFLAGS += $(MNIST_DATA_DIR)))
+$(eval $(call run_test_with_dependency,$O/test-mxnet,\
+	download-mnist))
+
+# run integration tests with all specified engines
+$(eval $(call run_test_with_engines,$O/test-mxnet))
 
 $O/%unittests: override LDFLAGS += -lz
 
 # run unittests with all specified engines
-$(eval $(call test_with_engines,$O/allunittests))
-
-$O/allunittests.stamp:
-	$Vtouch $@ # override default implementation
+$(eval $(call run_test_with_engines,$O/allunittests))

--- a/Build.mak
+++ b/Build.mak
@@ -12,9 +12,6 @@ endif
 download-mnist: $C/script/download-mnist
 	$(call exec,sh $(if $V,,-x) $^,$(MNIST_DATA_DIR),$^)
 
-# helper function to run tests
-run_test = $(call exec,MXNET_ENGINE_TYPE=$2 $1,$1,$2)
-
 # helper template to define targets for per-engine test runs
 define run_test_with_engine
 $(1).stamp: $(1)-$(2).stamp

--- a/Config.mak
+++ b/Config.mak
@@ -1,5 +1,7 @@
 INTEGRATIONTEST := integrationtest
 
+TEST_MXNET_ENGINES ?= NaiveEngine ThreadedEngine ThreadedEnginePerDevice
+
 MXNET_ENGINE_TYPE ?= NaiveEngine
 export MXNET_ENGINE_TYPE
 


### PR DESCRIPTION
This patch updates `Build.mak` to ensure that unittests and integration tests will always be run for all of the supported engine types.  As well as making it easier to run tests for all engines locally, this will make it possible to greatly simplify our CI setup.