### PR TITLE
Shutdown MXNet engine after running unittests

### DIFF
--- a/src/mxnet/API.d
+++ b/src/mxnet/API.d
@@ -29,6 +29,29 @@ version(UnitTest)
     import ocean.core.Test;
 }
 
+version (UnitTest)
+{
+    /***************************************************************************
+
+        Notifies the MXNet engine to shutdown after leaving `main` for
+        unittests
+
+        Shutting down the engine limits a race when interacting with MXNet
+        during process exit. The race happens when MXNet is cleaning up (on
+        process exit).
+
+        Note:
+           This only reduces the probability of the race but it does not seem
+           to eliminate them.
+
+    ***************************************************************************/
+
+    static ~this ()
+    {
+        notifyShutdown();
+    }
+}
+
 
 /*******************************************************************************
 

--- a/src/mxnet/API.d
+++ b/src/mxnet/API.d
@@ -119,3 +119,18 @@ unittest
     invoke!(mxNetSucceeds)(&answer);
     test!("==")(answer, 42);
 }
+
+
+/*******************************************************************************
+
+    Notifies MXNet to shutdown
+
+    By calling this function MXNet is notified to shut down its engine. When
+    the engine is shut down MXNet will not execute pending calculations.
+
+*******************************************************************************/
+
+public void notifyShutdown ()
+{
+    invoke!(MXNotifyShutdown)();
+}


### PR DESCRIPTION
This change notifies MXNet to shutdown in the module destructor of
`mxnet.Handle`. This reduces the likelihood of crashes due to a race
happening after executing unittests. The race is likely to be caused by
dmxnet interacting with MXNet while MXNet is cleaning up at process exit
(see sociomantic-tsunami/dmxnet#66 for more details).

Note, that it does not seem to eliminate those crashes. It only seems to
reduce it because there still seems to be the possibility of a race
happening until MXNet actually shuts down. In so far, this is only a
measure to reduce the number of these crashes since after all they
happen at process exit anyway. In future, one should look into making
dmxnet always exit properly when running the unittests.

Part of sociomantic-tsunami/dmxnet#66.