### PR TITLE
Update base docker image to dlang:v5

### DIFF
--- a/beaver.Dockerfile
+++ b/beaver.Dockerfile
@@ -1,3 +1,3 @@
-FROM sociomantictsunami/dlang:v4
+FROM sociomantictsunami/dlang:v5
 COPY docker/ /docker-tmp
 RUN /docker-tmp/build && rm -fr /docker-tmp


### PR DESCRIPTION
This new major release series of the dlang image provides:

  * dmd1 v1.082.x
  * dmd-transitional v2.071.x
  * dmd 2.080.x
  * tangort 1.9.x
  * d1to2fix v0.10.x