### PR TITLE
Update release notes

### DIFF
--- a/relnotes/api-notifyshutdown.feature.md
+++ b/relnotes/api-notifyshutdown.feature.md
@@ -1,0 +1,7 @@
+### Provide function to trigger shutdown of MXNet engine
+
+`mxnet.API`
+
+The function `notifyShutdown` is added to notify MXNet to shut down its
+execution engine. You may consider shutting down the engine manually to
+avoid/reduce races on process exit.

--- a/relnotes/multithreaded-engines.feature.md
+++ b/relnotes/multithreaded-engines.feature.md
@@ -1,0 +1,12 @@
+### Support multi-threaded MXNet engines
+
+`mxnet.MXNet`
+
+The changes to `NDArray.data` along with its required migrations enable the use
+of multi-threaded MXNet engines. Unit and integration tests pass for all
+engines and the restriction to the single-threaded `NaiveEngine` has been
+removed. Note though, that on process exit there is still a race after
+executing unittests. The race is likely to be caused by dmxnet interacting with
+MXNet while MXNet is cleaning up at process exit. This issue is still open and
+has only been partly addressed by instructing MXNet to shutdown. This makes the
+race less likely to occur.

--- a/relnotes/ndarray-data.migration.md
+++ b/relnotes/ndarray-data.migration.md
@@ -1,0 +1,13 @@
+### Synchronized read-only data slice for `NDArray.data()`
+
+`mxnet.NDArray`
+
+The `data` method of `NDArray` is changed to return a read-only slice (i.e., a
+slice of `const` elements). The added `const` implies that code writing
+elements of the returned slice has to be changed. There is no direct
+replacement. The closest option is to use the `copyFrom` method to copy all
+elements of a slice into an `NDArray`.
+
+Also the returned slice is synchronized. That means the method waits for all
+pending writes to finish prior to returning. Code performing `waitToRead()`
+(prior to calling `data`) manually should be removed.


### PR DESCRIPTION
This change adds missing release notes for the upcoming release.
Specifically, it provides release notes for the `notifyShutdown`
function introduced in commit 76d8e95 and the breaking changes to the
`NDArray.data` method introduced in commit 5f378b4. We also mention
that dmxnet supports now multi-threaded MXNet engines (used to be only
the single-threaded `NaiveEngine`) which is largely a result of the
above mentioned changes to `NDArray.data`. The tests should pass for any
MXNet engines (see commit 16fdf80). We also mention that there is still
a race on process exit that has been only partly addressed by using the
introduced `notifyShutdown` function (see commit f8b1c9a).