### PR TITLE
Add closure allocation check to CI stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,3 +66,10 @@ jobs:
           env: DMD=dmd-transitional F=devel MXNET_ENGINE_TYPE=ThreadedEngine
         - <<: *test-matrix
           env: DMD=dmd-transitional F=devel MXNET_ENGINE_TYPE=ThreadedEnginePerDevice
+
+        # Additional stages
+
+        - stage: Closure allocation check
+          env: DMD=dmd-transitional F=devel
+          install: beaver dlang install
+          script: ci/closures.sh

--- a/ci/closures.sh
+++ b/ci/closures.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -x -o pipefail
+
+# Enable printing of all potential GC allocation sources to stdout
+export DFLAGS=-vgc
+
+# Passes only if `make` succeeds and `grep` successfully finds no
+# `closure` (exit status 1); fails if either `make` or `grep` fail
+# or if `grep` finds at least one `closure`
+beaver dlang make fasttest 2>&1 | (grep -e "closure"; test $? -eq 1)


### PR DESCRIPTION
This should allow us to verify that we are not accidentally generating garbage via the use of closures.  We re-use ocean's `closure.sh` script, since its behaviour should be perfectly acceptable for our own use-case.