### PR TITLE
Replace all version (UnitTest) with version (unittest)

### DIFF
--- a/integrationtest/mxnet/main.d
+++ b/integrationtest/mxnet/main.d
@@ -24,7 +24,7 @@ import ocean.transition;
 import ocean.util.Convert;
 
 
-version (UnitTest) {} else
+version (unittest) {} else
 void main (istring[] args)
 {
     auto mnist_dataset_dir = MNIST.datasetPath(args);

--- a/src/mxnet/API.d
+++ b/src/mxnet/API.d
@@ -24,12 +24,12 @@ import mxnet.Exception;
 import ocean.text.util.StringC;
 import ocean.transition;
 
-version(UnitTest)
+version (unittest)
 {
     import ocean.core.Test;
 }
 
-version (UnitTest)
+version (unittest)
 {
     /***************************************************************************
 

--- a/src/mxnet/Atomic.d
+++ b/src/mxnet/Atomic.d
@@ -38,7 +38,7 @@ import ocean.text.convert.Formatter;
 import ocean.text.util.StringC;
 import ocean.transition;
 
-version (UnitTest)
+version (unittest)
 {
     import ocean.core.Test;
 }

--- a/src/mxnet/Context.d
+++ b/src/mxnet/Context.d
@@ -14,7 +14,7 @@
 
 module mxnet.Context;
 
-version(UnitTest)
+version (unittest)
 {
     import ocean.core.Test;
 }

--- a/src/mxnet/Exception.d
+++ b/src/mxnet/Exception.d
@@ -20,7 +20,7 @@ import ocean.core.Exception;
 import ocean.text.util.StringC;
 import ocean.transition;
 
-version(UnitTest)
+version (unittest)
 {
     import ocean.core.Test;
 }

--- a/src/mxnet/Executor.d
+++ b/src/mxnet/Executor.d
@@ -29,7 +29,7 @@ import ocean.text.util.StringC;
 import ocean.transition;
 import ocean.util.Convert;
 
-version(UnitTest)
+version (unittest)
 {
     import ocean.core.Test;
 }

--- a/src/mxnet/Handle.d
+++ b/src/mxnet/Handle.d
@@ -21,7 +21,7 @@ debug (MXNetHandle) import ocean.io.Stdout;
 import ocean.text.convert.Formatter;
 import ocean.transition;
 
-version (UnitTest)
+version (unittest)
 {
     import core.stdc.stdlib;
 
@@ -466,7 +466,7 @@ unittest
 }
 
 
-version (UnitTest)
+version (unittest)
 {
     /***************************************************************************
 

--- a/src/mxnet/NDArray.d
+++ b/src/mxnet/NDArray.d
@@ -26,7 +26,7 @@ import ocean.util.Convert;
 import ocean.text.util.StringC;
 import ocean.transition;
 
-version(UnitTest)
+version (unittest)
 {
     import ocean.core.Tuple;
     import ocean.core.Test;
@@ -1607,7 +1607,7 @@ unittest
 }
 
 
-version (UnitTest)
+version (unittest)
 {
     /***************************************************************************
 

--- a/src/mxnet/Symbol.d
+++ b/src/mxnet/Symbol.d
@@ -28,7 +28,7 @@ import ocean.text.util.StringC;
 import ocean.transition;
 import ocean.util.Convert;
 
-version(UnitTest)
+version (unittest)
 {
     import ocean.core.Test;
 }

--- a/src/mxnet/Util.d
+++ b/src/mxnet/Util.d
@@ -17,7 +17,7 @@ import ocean.transition;
 import ocean.core.Enforce;
 import ocean.text.convert.Formatter;
 
-version(UnitTest)
+version (unittest)
 {
     import ocean.core.Test;
     import Float = ocean.text.convert.Float;


### PR DESCRIPTION
Now dmxnet is D2-only we can rely on the compiler-defined version, which will be more robust than relying on the build system to correctly supply the `-version=UnitTest` flag alongside `-unittest`.