### PR TITLE
Remove or replace all imports of ocean.transition

### DIFF
--- a/integrationtest/mxnet/MNIST.d
+++ b/integrationtest/mxnet/MNIST.d
@@ -32,8 +32,8 @@ import ocean.io.compress.ZlibStream;
 import ocean.io.device.File;
 import ocean.io.Path;
 import ocean.math.Math;
+import ocean.meta.types.Qualifiers;
 import ocean.sys.Environment;
-import ocean.transition;
 
 
 // we use a nested function in this unittest example to ensure that

--- a/integrationtest/mxnet/main.d
+++ b/integrationtest/mxnet/main.d
@@ -19,8 +19,8 @@ import mxnet.MXNet;
 
 import ocean.core.Test;
 import ocean.io.Stdout;
+import ocean.meta.types.Qualifiers;
 import ocean.time.StopWatch;
-import ocean.transition;
 import ocean.util.Convert;
 
 

--- a/src/mxnet/API.d
+++ b/src/mxnet/API.d
@@ -21,8 +21,8 @@ module mxnet.API;
 import mxnet.c.c_api;
 import mxnet.Exception;
 
+import ocean.meta.types.Qualifiers;
 import ocean.text.util.StringC;
-import ocean.transition;
 
 version (unittest)
 {

--- a/src/mxnet/Atomic.d
+++ b/src/mxnet/Atomic.d
@@ -34,9 +34,9 @@ module mxnet.Atomic;
 import mxnet.c.c_api;
 import mxnet.API;
 
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Formatter;
 import ocean.text.util.StringC;
-import ocean.transition;
 
 version (unittest)
 {

--- a/src/mxnet/Exception.d
+++ b/src/mxnet/Exception.d
@@ -18,7 +18,6 @@ import mxnet.c.c_api;
 
 import ocean.core.Exception;
 import ocean.text.util.StringC;
-import ocean.transition;
 
 version (unittest)
 {

--- a/src/mxnet/Executor.d
+++ b/src/mxnet/Executor.d
@@ -26,7 +26,6 @@ import mxnet.NDArray;
 import mxnet.Symbol;
 
 import ocean.text.util.StringC;
-import ocean.transition;
 import ocean.util.Convert;
 
 version (unittest)

--- a/src/mxnet/Handle.d
+++ b/src/mxnet/Handle.d
@@ -18,8 +18,8 @@ import mxnet.Exception;
 import core.sys.posix.unistd;
 
 debug (MXNetHandle) import ocean.io.Stdout;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Formatter;
-import ocean.transition;
 
 version (unittest)
 {

--- a/src/mxnet/NDArray.d
+++ b/src/mxnet/NDArray.d
@@ -22,9 +22,9 @@ import mxnet.Util;
 
 import ocean.core.array.Search;
 import ocean.core.Tuple;
+import ocean.meta.types.Qualifiers;
 import ocean.util.Convert;
 import ocean.text.util.StringC;
-import ocean.transition;
 
 version (unittest)
 {

--- a/src/mxnet/Symbol.d
+++ b/src/mxnet/Symbol.d
@@ -23,9 +23,9 @@ import mxnet.Util;
 import core.exception;
 
 import ocean.core.Enforce;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Formatter;
 import ocean.text.util.StringC;
-import ocean.transition;
 import ocean.util.Convert;
 
 version (unittest)

--- a/src/mxnet/Util.d
+++ b/src/mxnet/Util.d
@@ -13,8 +13,8 @@
 
 module mxnet.Util;
 
-import ocean.transition;
 import ocean.core.Enforce;
+import ocean.meta.types.Qualifiers;
 import ocean.text.convert.Formatter;
 
 version (unittest)

--- a/src/mxnet/c/c_api.d
+++ b/src/mxnet/c/c_api.d
@@ -32,9 +32,6 @@
 module mxnet.c.c_api;
 
 
-import ocean.transition;
-
-
 /*!
  *  Copyright (c) 2015 by Contributors
  * \file c_api.h


### PR DESCRIPTION
For modules that use the `istring`, `cstring` or `mstring` aliases, we replace `ocean.transition` imports with `ocean.meta.types.Qualifiers`.  In all other modules the `ocean.transition` import is just dropped, as dmxnet no longer uses any of the functionality it defines.