### PR TITLE
Encapsulate imports required for debugReport helper function

### DIFF
--- a/src/mxnet/Handle.d
+++ b/src/mxnet/Handle.d
@@ -15,11 +15,7 @@ module mxnet.Handle;
 
 import mxnet.Exception;
 
-import core.sys.posix.unistd;
-
-debug (MXNetHandle) import ocean.io.Stdout;
 import ocean.meta.types.Qualifiers;
-import ocean.text.convert.Formatter;
 
 version (unittest)
 {
@@ -455,6 +451,8 @@ public class MXNetHandle (HandleType, alias FreeHandleFunction)
 
 private void debugReport (Args...) (cstring fmt, Args args)
 {
+    import core.sys.posix.unistd : write, STDERR_FILENO;
+    import ocean.text.convert.Formatter : sformat;
     sformat((cstring str) { write(STDERR_FILENO, str.ptr, str.length); },
             fmt, args);
 }


### PR DESCRIPTION
Imports from `core.sys.posix.unistd` and `ocean.text.convert.Formatter` have been encapsulated inside the `debugReport` function, since they are unused by any other part of the `mxnet.Handle` module.  This is a little bit bikesheddy, but ensures that debug helper functionality is cleanly separated from production code.

The import of `ocean.io.Stdout` is no longer used (it's just a hangover from an earlier implementation), so we just drop it.