### PR TITLE
Advance ocean from v4.2.11+d2 to v4.4.1+d2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Submodules
 ========== =======
 Dependency Version
 ========== =======
-ocean      v4.2.x
+ocean      v4.4.x
 ========== =======
 
 If you plan to use the provided ``Makefile`` (e.g. to run integration tests),

--- a/relnotes/ocean.migration.md
+++ b/relnotes/ocean.migration.md
@@ -1,0 +1,4 @@
+### Increase minimum required ocean version to v4.4.x
+
+This brings dmxnet's ocean dependency up to date with the latest stable
+minor release series.


### PR DESCRIPTION
ocean v4.2.11+d2(c21b9be0)...v4.4.1+d2(bfc02108)

Release notes: https://github.com/sociomantic-tsunami/ocean/releases/tag/v4.4.1+d2
Changed commits: https://github.com/sociomantic-tsunami/ocean/compare/v4.2.11+d2...v4.4.1+d2