### PR TITLE
Use enum for manifest constants

### DIFF
--- a/src/mxnet/NDArray.d
+++ b/src/mxnet/NDArray.d
@@ -822,7 +822,7 @@ public alias Tuple!(float, double, int, ubyte) SupportedElementTypes;
 
 public template isSupportedElementType (T)
 {
-    static immutable bool isSupportedElementType =
+    enum bool isSupportedElementType =
         IndexOf!(T, SupportedElementTypes) < SupportedElementTypes.length;
 }
 

--- a/src/mxnet/Util.d
+++ b/src/mxnet/Util.d
@@ -49,14 +49,14 @@ version (unittest)
 
 public mstring toNoLossString (in float x, mstring buf)
 {
-    static immutable max_length = 1 + // optional minus sign
-                       1 + // leading decimal digit
-                       1 + // .
-                       8 + // 8 decimal digits
-                       1 + // e
-                       1 + // sign
-                       2;  // decimal exponent
-    static immutable format_string = "{:e8}";
+    enum max_length = 1 + // optional minus sign
+                      1 + // leading decimal digit
+                      1 + // .
+                      8 + // 8 decimal digits
+                      1 + // e
+                      1 + // sign
+                      2;  // decimal exponent
+    enum format_string = "{:e8}";
 
     enforce(buf.length >= max_length);
     return snformat(buf, format_string, x);


### PR DESCRIPTION
This change replaces all uses of `static immutable` with `enum` where
the use of manifest constant won't cause an allocation. Specifically,
this is the case when defining manifest constants using non-array
literals (which includes string literals).

When converting to D2-only (see 6b81096) D1 `const` was replaced by
`static immutable`. In all these cases D1 `const` served as a manifest
constant. In D2 `enum` is used to define manifest constants. This is
preferred except when done for array literals accessed more than once
when running. Because in this case each use of the manifest constant will
cause an allocation which is often not wanted. This does not apply to
string literals which are treated specially. Hence, using an `enum` for
a string literal carries no risk of allocation when used and is usually
fine. Using `enum` with this in mind enables replacing `static immutable`
which is clearer in intent and avoids any possible need for static memory
to hold the immutable data.