### PR TITLE
Update D bindings to MXNet version 1.1.0

### DIFF
--- a/relnotes/c-api-1.1.0.feature.md
+++ b/relnotes/c-api-1.1.0.feature.md
@@ -1,0 +1,6 @@
+### Update D bindings to MXNet version 1.1.0
+
+`mxnet.c.c_api`
+
+The bindings to the MXNet C interfaces are updated to match MXNet 1.1.0. The
+changes should be backward compatible.


### PR DESCRIPTION
This change updates the generated D bindings for the MXNet C interface.
The old bindings were generated from MXNet v0.10.0. This update provides
the changes for MXNet 1.1.0.

Note, all changes are backward compatible.