### PR TITLE
Fix reporting of testing accuracy in percentage

### DIFF
--- a/integrationtest/mxnet/main.d
+++ b/integrationtest/mxnet/main.d
@@ -144,7 +144,8 @@ void main (istring[] args)
     auto testing_accuracy = accuracy(predicted_testing_labels, mnist_testing_labels);
     // prediction on testing
     test!(">=")(testing_accuracy, 0.915);
-    Stdout.formatln("Percentage of correctly predicted digits on MNIST testing: {:f4}%", testing_accuracy);
+    Stdout.formatln("Percentage of correctly predicted digits on MNIST testing: {:f2}%",
+                    testing_accuracy * 100);
     Stdout.formatln("Calculated in {:f6} seconds", iteration_time_sec);
     Stdout.formatln("MXNet handles in use at finish: {}", handleCount());
 }


### PR DESCRIPTION
The accuracy for the MNIST integration test reports in percentages of
correctly classified hand-written digits. But the calculation is missing
a multiplication by one hundred to be proper which is fixed in the
change.