### PR TITLE
Remove unnecessary conversion to array

### DIFF
--- a/integrationtest/mxnet/main.d
+++ b/integrationtest/mxnet/main.d
@@ -199,7 +199,7 @@ size_t[] predict (Symbol model, NDArray!(float) matrix_w,
     scope (exit) output.freeHandle();
     auto outputs = [output];
     executor.outputs(outputs);
-    auto predictions_vector = to!(float[])(output.data());
+    auto predictions_vector = output.data();
 
     auto predictions = new size_t[num_images];
     for (uint i = 0; i < num_images; ++i)


### PR DESCRIPTION
This change removes the unnecessary conversion of the outputted
predicted probabilities for the integration test. This conversion is not
needed because we can directly refer to the returned data.